### PR TITLE
src/main.rs: add support for exclude flag

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -55,10 +55,12 @@ impl<'a> Document<'a> {
     fn new_located_event(&self, event: Event) -> LocatedEvent {
         LocatedEvent {
             event,
-            line: self.newlines
+            line: self
+                .newlines
                 .iter()
                 .take_while(|&&i| i < self.parser.get_offset())
-                .count() + 1,
+                .count()
+                + 1,
         }
     }
 }


### PR DESCRIPTION
This commit adds support for the `exclude` flag, which will skip
over any files in a path specified by the flag. The excluded path
is relative to the root and the flag supports taking multiple
values separated by spaces.

Resolves #18 