### PR TITLE
Publish released version binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,12 +5,11 @@ on:
     tags:
       - "**"
 
-permissions:
-  contents: write
-
 jobs:
   release:
     name: Create release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +20,10 @@ jobs:
   assets:
     name: Create artifact
     needs: release
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
     strategy:
       matrix:
         include:
@@ -51,8 +54,14 @@ jobs:
           mkdir -p $NAME
           cp ${{ steps.build.outputs.path }} $NAME/
           tar --create --gzip --file $NAME.tar.gz $NAME/
+          echo name=$NAME >> $GITHUB_OUTPUT
           echo path=$NAME.tar.gz >> $GITHUB_OUTPUT
       - name: Upload artifact
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload ${{ github.ref_name }} ${{ steps.package.outputs.path }}
+      - name: Generate attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ steps.build.outputs.path }}
+          subject-name: ${{ steps.package.outputs.name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "**"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{ github.ref_name }}
+
+  assets:
+    name: Create artifact
+    needs: release
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable
+          rustup target install ${{ matrix.target }}
+      - name: Build executable
+        id: build
+        run: |
+          cargo build --release --target ${{ matrix.target }} --no-default-features
+          echo path=target/${{ matrix.target }}/release/marker >> $GITHUB_OUTPUT
+      - name: Package executable
+        id: package
+        env:
+          NAME: marker-${{ github.ref_name }}-${{ matrix.target }}
+        run: |
+          mkdir -p $NAME
+          cp ${{ steps.build.outputs.path }} $NAME/
+          tar --create --gzip --file $NAME.tar.gz $NAME/
+          echo path=$NAME.tar.gz >> $GITHUB_OUTPUT
+      - name: Upload artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload ${{ github.ref_name }} ${{ steps.package.outputs.path }}


### PR DESCRIPTION
At @etcd-io, we're using marker as linter. We're moving our infrastructure to an environment that doesn't have Rust/Cargo available. We would like to be able to download a binary without having to install Rust.

With this PR, I introduce a GitHub action that gets triggered when a tag is pushed. It builds the binaries and publishes them as a GitHub release. You can see a fictional release at my fork: https://github.com/ivanvc/marker/releases/tag/v0.9.12

I also vendorized OpenSSL, as it was a challenge to get it working in a GitHub runner.